### PR TITLE
LUN-879 -- When checking for administered sites also check for global page permissions that directly reference the user

### DIFF
--- a/cmsroles/siteadmin.py
+++ b/cmsroles/siteadmin.py
@@ -27,11 +27,17 @@ def get_administered_sites(user):
     if user.is_superuser:
         return [s for s in Site.objects.all()]
     sites = []
+
+    def lookup_sites(auth_obj):
+        for global_perm in auth_obj.globalpagepermission_set.\
+                prefetch_related('sites').all():
+            sites.extend(global_perm.sites.all())
+
     for group in user.groups.all():
         if is_site_admin_group(group):
-            for global_perm in group.globalpagepermission_set.\
-                    prefetch_related('sites').all():
-                sites.extend(global_perm.sites.all())
+            lookup_sites(group)
+    lookup_sites(user)
+
     return sites
 
 

--- a/cmsroles/tests.py
+++ b/cmsroles/tests.py
@@ -69,6 +69,18 @@ class BasicSiteSetupTest(TestCase):
         self.assertEquals([s.domain for s in administered_sites],
                           ['bar.site.com'])
 
+    def test_get_administered_sites_with_user_referencing_glob_page_(self):
+        foo_site = Site.objects.create(name='foo.site.com', domain='foo.site.com')
+        admin_user = User.objects.create(username='gigi', password='baston')
+        site_admin_perms = Permission.objects.filter(content_type__model='user')
+        for perm in site_admin_perms:
+            admin_user.user_permissions.add(perm)
+        gpp = GlobalPagePermission.objects.create(user=admin_user)
+        gpp.sites.add(foo_site)
+        administered_sites = get_administered_sites(admin_user)
+        self.assertEquals(len(administered_sites), 1)
+        self.assertEquals([s.pk for s in administered_sites], [foo_site.pk])
+
     def test_not_accessible_for_non_siteadmins(self):
         joe = User.objects.create_user(
             username='joe', password='x', email='joe@mata.com')

--- a/cmsroles/views.py
+++ b/cmsroles/views.py
@@ -35,7 +35,9 @@ class BaseUserFormSet(BaseFormSet):
                 continue
             if user in users:
                 raise forms.ValidationError(
-                    "A User can't have multiple roles in the same site")
+                    "User %s has multiple roles. "
+                    "A User can't have multiple roles in the same site"
+                    % user.username)
             users.add(user)
 
 


### PR DESCRIPTION
Besides the actual fix, the commit also changes the error message the site admin gets when he tries to give two roles to the same user. The username is given in the error message so that the site admin can more easily 'debug' the problem.
