### PR TITLE
LUN-954 -- Only unassign the user from the non-site-wide group once he has no more page permissions on any of the sites

### DIFF
--- a/cmsroles/models.py
+++ b/cmsroles/models.py
@@ -204,7 +204,8 @@ class Role(AbstractPagePermission):
         else:
             for perm in self.derived_page_permissions.filter(page__site=site, user=user):
                 perm.delete()
-            user.groups.remove(self.group)
+            if self.derived_page_permissions.count() == 0:
+                user.groups.remove(self.group)
 
     def all_users(self):
         """Returns all users having this role."""


### PR DESCRIPTION
- unassigning him otherise would cause him to loose his role on ALL sites, not just the one passed in as an argument to ungrant_from_user
- also do a couple of small refactorings to the non-site-wide unit tests
